### PR TITLE
Introduce API to refresh OAuth2 token and introduce default token expiry time

### DIFF
--- a/oauth2-ballerina/client_oauth2_provider.bal
+++ b/oauth2-ballerina/client_oauth2_provider.bal
@@ -206,6 +206,20 @@ public class ClientOAuth2Provider {
         }
         return checkpanic authToken;
     }
+
+    # Refresh a token for the OAuth2 authentication.
+    # ```ballerina
+    # string:oauth2:Error token = provider.refreshToken();
+    # ```
+    #
+    # + return - Generated `string` token or else an `oauth2:Error` if an error occurred
+    public isolated function refreshToken() returns string|Error {
+        string|Error authToken = refreshOAuth2Token(self.grantConfig, self.tokenCache);
+        if (authToken is Error) {
+            return prepareError("Failed to refresh OAuth2 token.", authToken);
+        }
+        return checkpanic authToken;
+    }
 }
 
 // Generates the OAuth2 token.
@@ -216,6 +230,17 @@ isolated function generateOAuth2Token(GrantConfig grantConfig, TokenCache tokenC
         return getOAuth2TokenForClientCredentialsGrant(grantConfig, tokenCache);
     } else {
         return getOAuth2TokenForDirectTokenMode(grantConfig, tokenCache);
+    }
+}
+
+// Refreshes the OAuth2 token.
+isolated function refreshOAuth2Token(GrantConfig grantConfig, TokenCache tokenCache) returns string|Error {
+    if (grantConfig is PasswordGrantConfig) {
+        return getAccessTokenFromRefreshRequest(grantConfig, tokenCache);
+    } else if (grantConfig is ClientCredentialsGrantConfig) {
+        return getAccessTokenFromAuthorizationRequest(grantConfig, tokenCache);
+    } else {
+        return getAccessTokenFromRefreshRequest(grantConfig, tokenCache);
     }
 }
 

--- a/oauth2-ballerina/client_oauth2_provider.bal
+++ b/oauth2-ballerina/client_oauth2_provider.bal
@@ -27,7 +27,7 @@ import ballerina/time;
 # + parameters - Map of endpoint parameters use with the authorization endpoint
 # + credentialBearer - Bearer of the authentication credentials, which is sent to the authorization endpoint
 # + clientConfig - HTTP client configurations, which are used to call the authorization endpoint
-public type ClientCredentialsGrantConfig record {|
+public type ClientCredentialsGrantConfig record {
     string tokenUrl;
     string clientId;
     string clientSecret;
@@ -37,7 +37,7 @@ public type ClientCredentialsGrantConfig record {|
     map<string> parameters?;
     CredentialBearer credentialBearer = AUTH_HEADER_BEARER;
     ClientConfiguration clientConfig = {};
-|};
+};
 
 # The data structure, which is used to configure the OAuth2 password grant type.
 #
@@ -53,7 +53,7 @@ public type ClientCredentialsGrantConfig record {|
 # + parameters - Map of endpoint parameters use with the authorization endpoint
 # + credentialBearer - Bearer of the authentication credentials, which is sent to the authorization endpoint
 # + clientConfig - HTTP client configurations, which are used to call the authorization endpoint
-public type PasswordGrantConfig record {|
+public type PasswordGrantConfig record {
     string tokenUrl;
     string username;
     string password;
@@ -66,7 +66,7 @@ public type PasswordGrantConfig record {|
     map<string> parameters?;
     CredentialBearer credentialBearer = AUTH_HEADER_BEARER;
     ClientConfiguration clientConfig = {};
-|};
+};
 
 # The data structure, which is used to configure the OAuth2 access token directly.
 #
@@ -75,13 +75,13 @@ public type PasswordGrantConfig record {|
 # + defaultTokenExpTimeInSeconds - Expiration time of the tokens if authorization server response does not contain an `expires_in` field
 # + clockSkewInSeconds - Clock skew in seconds
 # + credentialBearer - Bearer of the authentication credentials, which is sent to the authorization endpoint
-public type DirectTokenConfig record {|
+public type DirectTokenConfig record {
     string accessToken?;
     DirectTokenRefreshConfig refreshConfig?;
     int defaultTokenExpTimeInSeconds = 3600;
     int clockSkewInSeconds = 0;
     CredentialBearer credentialBearer = AUTH_HEADER_BEARER;
-|};
+};
 
 # The data structure, which can be used to pass the configurations for refreshing the access token of
 # the password grant type.


### PR DESCRIPTION
## Purpose
This PR introduces an API to refresh OAuth2 token, which directly calls to authorization endpoint when client credentials grant config is provided or refresh endpoint otherwise. This is used by the HTTP client, when the token is expired or revoked.

Default token expiry time is introduced for the token which does not receive an expiry time from the authorization/refresh endpoint. This is used for the token cache.

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/584