### PR TITLE
Remove a credential bearer type of OAuth2 client

### DIFF
--- a/oauth2-ballerina/oauth2_commons.bal
+++ b/oauth2-ballerina/oauth2_commons.bal
@@ -48,8 +48,7 @@ public type SecureSocket record {|
 # Represents HTTP versions.
 public enum CredentialBearer {
     AUTH_HEADER_BEARER,
-    POST_BODY_BEARER,
-    NO_BEARER
+    POST_BODY_BEARER
 }
 
 isolated function doHttpRequest(string url, ClientConfiguration clientConfig, map<string> headers, string payload)


### PR DESCRIPTION
## Purpose
$subject

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/584