### PR TITLE
Add OAuth2 client auth support for introspection request

### DIFF
--- a/oauth2-ballerina/listener_oauth2_provider.bal
+++ b/oauth2-ballerina/listener_oauth2_provider.bal
@@ -128,7 +128,8 @@ public class ListenerOAuth2Provider {
                 return response;
             }
         }
-        IntrospectionResponse|Error validationResult = validate(credential, self.introspectionConfig, self.clientOAuth2Provider, optionalParams);
+        IntrospectionResponse|Error validationResult = validate(credential, self.introspectionConfig,
+                                                                self.clientOAuth2Provider, optionalParams);
         if (validationResult is Error) {
             return prepareError("OAuth2 validation failed.", validationResult);
         }
@@ -141,8 +142,8 @@ public class ListenerOAuth2Provider {
 }
 
 // Validates the provided OAuth2 token by calling the OAuth2 introspection endpoint.
-isolated function validate(string token, IntrospectionConfig config, ClientOAuth2Provider? clientOAuth2Provider, map<string>? optionalParams)
-                           returns IntrospectionResponse|Error {
+isolated function validate(string token, IntrospectionConfig config, ClientOAuth2Provider? clientOAuth2Provider,
+                           map<string>? optionalParams) returns IntrospectionResponse|Error {
     // Builds the request to be sent to the introspection endpoint. For more information, refer to the
     // [OAuth 2.0 Token Introspection RFC](https://tools.ietf.org/html/rfc7662#section-2.1)
     string textPayload = "token=" + token;

--- a/oauth2-ballerina/oauth2_commons.bal
+++ b/oauth2-ballerina/oauth2_commons.bal
@@ -22,13 +22,18 @@ import ballerina/jballerina.java;
 # + httpVersion - The HTTP version of the client
 # + customHeaders - The list of custom HTTP headers
 # + customPayload - The list of custom HTTP payload parameters
+# + auth - The client auth configurations
 # + secureSocket - SSL/TLS related configurations
 public type ClientConfiguration record {|
     HttpVersion httpVersion = HTTP_1_1;
     map<string> customHeaders?;
     string customPayload?;
+    ClientAuth auth?;
     SecureSocket secureSocket?;
 |};
+
+# Defines the authentication configuration types for the HTTP client used for token introspection.
+public type ClientAuth ClientCredentialsGrantConfig|PasswordGrantConfig|DirectTokenConfig;
 
 # Represents HTTP versions.
 public enum HttpVersion {

--- a/oauth2-ballerina/tests/listener_oauth2_provider_test.bal
+++ b/oauth2-ballerina/tests/listener_oauth2_provider_test.bal
@@ -123,3 +123,179 @@ isolated function testIntrospectionServer3() {
         test:assertFail(msg = "Test Failed! ");
     }
 }
+
+// Test the introspection request with successful token with valid OAuth2 client credentials grant type
+@test:Config {
+    groups: ["provider"]
+}
+isolated function testIntrospectionServer4() {
+    string accessToken = getAccessToken();
+    IntrospectionConfig config = {
+        url: "https://localhost:9443/oauth2/introspect",
+        clientConfig: {
+            auth: {
+                tokenUrl: "https://localhost:9443/oauth2/token",
+                clientId: "FlfJYKBD2c925h4lkycqNZlC2l4a",
+                clientSecret: "PJz0UhTJMrHOo68QQNpvnqAY_3Aa",
+                clientConfig: {
+                    secureSocket: {
+                       trustStore: {
+                           path: WSO2_TRUSTSTORE_PATH,
+                           password: "wso2carbon"
+                       }
+                    }
+                }
+            },
+            secureSocket: {
+               trustStore: {
+                   path: WSO2_TRUSTSTORE_PATH,
+                   password: "wso2carbon"
+               }
+            }
+        }
+    };
+    ListenerOAuth2Provider provider = new(config);
+    IntrospectionResponse|Error response = provider.authorize(accessToken);
+    if (response is IntrospectionResponse) {
+        test:assertTrue(response.active);
+        test:assertEquals(response?.scope, "view-order");
+        test:assertEquals(response?.clientId, "FlfJYKBD2c925h4lkycqNZlC2l4a");
+        test:assertEquals(response?.username, "admin@carbon.super");
+        test:assertEquals(response?.tokenType, "Bearer");
+        test:assertTrue(response?.exp is int);
+        test:assertTrue(response?.iat is int);
+        test:assertTrue(response?.nbf is int);
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+}
+
+// Test the introspection request with successful token with valid OAuth2 password grant type
+@test:Config {
+    groups: ["provider"]
+}
+isolated function testIntrospectionServer5() {
+    string accessToken = getAccessToken();
+    IntrospectionConfig config = {
+        url: "https://localhost:9443/oauth2/introspect",
+        clientConfig: {
+            auth: {
+                tokenUrl: "https://localhost:9443/oauth2/token",
+                username: "admin",
+                password: "admin",
+                clientId: "FlfJYKBD2c925h4lkycqNZlC2l4a",
+                clientSecret: "PJz0UhTJMrHOo68QQNpvnqAY_3Aa",
+                scopes: ["view-order"],
+                clientConfig: {
+                    secureSocket: {
+                       trustStore: {
+                           path: WSO2_TRUSTSTORE_PATH,
+                           password: "wso2carbon"
+                       }
+                    }
+                }
+            },
+            secureSocket: {
+               trustStore: {
+                   path: WSO2_TRUSTSTORE_PATH,
+                   password: "wso2carbon"
+               }
+            }
+        }
+    };
+    ListenerOAuth2Provider provider = new(config);
+    IntrospectionResponse|Error response = provider.authorize(accessToken);
+    if (response is IntrospectionResponse) {
+        test:assertTrue(response.active);
+        test:assertEquals(response?.scope, "view-order");
+        test:assertEquals(response?.clientId, "FlfJYKBD2c925h4lkycqNZlC2l4a");
+        test:assertEquals(response?.username, "admin@carbon.super");
+        test:assertEquals(response?.tokenType, "Bearer");
+        test:assertTrue(response?.exp is int);
+        test:assertTrue(response?.iat is int);
+        test:assertTrue(response?.nbf is int);
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+}
+
+// Test the introspection request with successful token with invalid OAuth2 client credentials grant type
+@test:Config {
+    groups: ["provider"]
+}
+isolated function testIntrospectionServer6() {
+    string accessToken = getAccessToken();
+    IntrospectionConfig config = {
+        url: "https://localhost:9443/oauth2/introspect",
+        clientConfig: {
+            auth: {
+                tokenUrl: "https://localhost:9443/oauth2/token",
+                clientId: "invalid_client_id",
+                clientSecret: "invalid_client_secret",
+                clientConfig: {
+                    secureSocket: {
+                       trustStore: {
+                           path: WSO2_TRUSTSTORE_PATH,
+                           password: "wso2carbon"
+                       }
+                    }
+                }
+            },
+            secureSocket: {
+               trustStore: {
+                   path: WSO2_TRUSTSTORE_PATH,
+                   password: "wso2carbon"
+               }
+            }
+        }
+    };
+    ListenerOAuth2Provider provider = new(config);
+    IntrospectionResponse|Error response = provider.authorize(accessToken);
+    if (response is Error) {
+        assertContains(response, "Failed to get a success response from the endpoint. Response Code: '401'.");
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+}
+
+// Test the introspection request with successful token with invalid OAuth2 password grant type
+@test:Config {
+    groups: ["provider"]
+}
+isolated function testIntrospectionServer7() {
+    string accessToken = getAccessToken();
+    IntrospectionConfig config = {
+        url: "https://localhost:9443/oauth2/introspect",
+        clientConfig: {
+            auth: {
+                tokenUrl: "https://localhost:9443/oauth2/token",
+                username: "invalid_username",
+                password: "invalid_password",
+                clientId: "invalid_client_id",
+                clientSecret: "invalid_client_secret",
+                scopes: ["view-order"],
+                clientConfig: {
+                    secureSocket: {
+                       trustStore: {
+                           path: WSO2_TRUSTSTORE_PATH,
+                           password: "wso2carbon"
+                       }
+                    }
+                }
+            },
+            secureSocket: {
+               trustStore: {
+                   path: WSO2_TRUSTSTORE_PATH,
+                   password: "wso2carbon"
+               }
+            }
+        }
+    };
+    ListenerOAuth2Provider provider = new(config);
+    IntrospectionResponse|Error response = provider.authorize(accessToken);
+    if (response is Error) {
+        assertContains(response, "Failed to get a success response from the endpoint. Response Code: '401'.");
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+}


### PR DESCRIPTION
## Purpose
This PR add support for the OAuth2 client authentication of JDK11 HTTP client, which is used for OAuth2 introspection.

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/935

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/584