### PR TITLE
Generate OAuth2 token while provider is initialized

### DIFF
--- a/oauth2-ballerina/client_oauth2_provider.bal
+++ b/oauth2-ballerina/client_oauth2_provider.bal
@@ -177,6 +177,11 @@ public class ClientOAuth2Provider {
     public isolated function init(GrantConfig grantConfig) {
         self.grantConfig = grantConfig;
         self.tokenCache = initTokenCache();
+        // This generates the token and keep it in the `TokenCache` to be used by the initial request.
+        string|Error result = generateOAuth2Token(self.grantConfig, self.tokenCache);
+        if (result is Error) {
+            panic result;
+        }
     }
 
     # Get an OAuth2 access token from authorization server for the OAuth2 authentication.

--- a/oauth2-ballerina/tests/client_oauth2_provider_test.bal
+++ b/oauth2-ballerina/tests/client_oauth2_provider_test.bal
@@ -75,20 +75,18 @@ isolated function testClientCredentialsGrantType2() {
             }
         }
     };
-    ClientOAuth2Provider provider = new(config);
-    string|Error response = provider.generateToken();
-    if (response is Error) {
-        assertContains(response, "A valid OAuth client could not be found for client_id: invalid_client_id");
+    ClientOAuth2Provider|error provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "A valid OAuth client could not be found for client_id: invalid_client_id");
     } else {
         test:assertFail(msg = "Test Failed! ");
     }
 
     // Send the credentials in request body
     config.credentialBearer = POST_BODY_BEARER;
-    provider = new(config);
-    response = provider.generateToken();
-    if (response is Error) {
-        assertContains(response, "A valid OAuth client could not be found for client_id: invalid_client_id");
+    provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "A valid OAuth client could not be found for client_id: invalid_client_id");
     } else {
         test:assertFail(msg = "Test Failed! ");
     }
@@ -113,20 +111,18 @@ isolated function testClientCredentialsGrantType3() {
             }
         }
     };
-    ClientOAuth2Provider provider = new(config);
-    string|Error response = provider.generateToken();
-    if (response is Error) {
-        assertContains(response, "Client Authentication failed.");
+    ClientOAuth2Provider|error provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "Client Authentication failed.");
     } else {
         test:assertFail(msg = "Test Failed! ");
     }
 
     // Send the credentials in request body
     config.credentialBearer = POST_BODY_BEARER;
-    provider = new(config);
-    response = provider.generateToken();
-    if (response is Error) {
-        assertContains(response, "Client Authentication failed.");
+    provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "Client Authentication failed.");
     } else {
         test:assertFail(msg = "Test Failed! ");
     }
@@ -257,20 +253,18 @@ isolated function testPasswordGrantType3() {
             }
         }
     };
-    ClientOAuth2Provider provider = new(config);
-    string|Error response = provider.generateToken();
-    if (response is Error) {
-        assertContains(response, "Authentication failed for invalid_username");
+    ClientOAuth2Provider|error provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "Authentication failed for invalid_username");
     } else {
         test:assertFail(msg = "Test Failed! ");
     }
 
     // Send the credentials in request body
     config.credentialBearer = POST_BODY_BEARER;
-    provider = new(config);
-    response = provider.generateToken();
-    if (response is Error) {
-        assertContains(response, "Authentication failed for invalid_username");
+    provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "Authentication failed for invalid_username");
     } else {
         test:assertFail(msg = "Test Failed! ");
     }
@@ -296,10 +290,9 @@ isolated function testDirectToken1() {
             }
         }
     };
-    ClientOAuth2Provider provider = new(config);
-    string|Error response = provider.generateToken();
-    if (response is Error) {
-        assertContains(response, "Persisted access token data not found");
+    ClientOAuth2Provider|error provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "Persisted access token data not found");
     } else {
         test:assertFail(msg = "Test Failed! ");
     }

--- a/oauth2-ballerina/tests/listener_oauth2_provider_test.bal
+++ b/oauth2-ballerina/tests/listener_oauth2_provider_test.bal
@@ -246,10 +246,9 @@ isolated function testIntrospectionServer6() {
             }
         }
     };
-    ListenerOAuth2Provider provider = new(config);
-    IntrospectionResponse|Error response = provider.authorize(accessToken);
-    if (response is Error) {
-        assertContains(response, "Failed to get a success response from the endpoint. Response Code: '401'.");
+    ListenerOAuth2Provider|error provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "Failed to get a success response from the endpoint. Response Code: '401'.");
     } else {
         test:assertFail(msg = "Test Failed! ");
     }
@@ -288,10 +287,9 @@ isolated function testIntrospectionServer7() {
             }
         }
     };
-    ListenerOAuth2Provider provider = new(config);
-    IntrospectionResponse|Error response = provider.authorize(accessToken);
-    if (response is Error) {
-        assertContains(response, "Failed to get a success response from the endpoint. Response Code: '401'.");
+    ListenerOAuth2Provider|error provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "Failed to get a success response from the endpoint. Response Code: '401'.");
     } else {
         test:assertFail(msg = "Test Failed! ");
     }

--- a/oauth2-ballerina/tests/test_utils.bal
+++ b/oauth2-ballerina/tests/test_utils.bal
@@ -33,7 +33,7 @@ isolated function assertToken(string token) {
     test:assertEquals(parts[4].length(), 12);
 }
 
-isolated function assertContains(Error err, string text) {
+isolated function assertContains(error err, string text) {
     string message = err.message();
     var cause = err.cause();
     if (cause is error) {


### PR DESCRIPTION
## Purpose
This PR generates the OAuth2 access token while provider is initialized  and keeps it in the `TokenCache` to be used by the initial request.

Related to: https://github.com/ballerina-platform/ballerina-standard-library/issues/584