### PR TITLE
Update for refresh token grant config

### DIFF
--- a/oauth2-ballerina/client_oauth2_provider.bal
+++ b/oauth2-ballerina/client_oauth2_provider.bal
@@ -60,7 +60,13 @@ public type PasswordGrantConfig record {|
     string clientId?;
     string clientSecret?;
     string[] scopes?;
-    RefreshConfig refreshConfig?;
+    record {|
+        string refreshUrl;
+        string[] scopes?;
+        map<string> optionalParams?;
+        CredentialBearer credentialBearer = AUTH_HEADER_BEARER;
+        ClientConfiguration clientConfig = {};
+    |} refreshConfig?;
     decimal defaultTokenExpTime = 3600;
     decimal clockSkew = 0;
     map<string> optionalParams?;
@@ -88,22 +94,6 @@ public type DirectTokenConfig record {|
     string[] scopes?;
     decimal defaultTokenExpTime = 3600;
     decimal clockSkew = 0;
-    map<string> optionalParams?;
-    CredentialBearer credentialBearer = AUTH_HEADER_BEARER;
-    ClientConfiguration clientConfig = {};
-|};
-
-# The data structure, which can be used to pass the configurations for refreshing the access token of
-# the password grant type.
-#
-# + refreshUrl - Refresh token URL for the refresh token server
-# + scopes - Scope(s) of the access request
-# + optionalParams - Map of optional parameters use for the authorization endpoint
-# + credentialBearer - Bearer of the authentication credentials, which is sent to the authorization endpoint
-# + clientConfig - HTTP client configurations, which are used to call the authorization endpoint
-public type RefreshConfig record {|
-    string refreshUrl;
-    string[] scopes?;
     map<string> optionalParams?;
     CredentialBearer credentialBearer = AUTH_HEADER_BEARER;
     ClientConfiguration clientConfig = {};
@@ -336,8 +326,8 @@ isolated function getAccessTokenFromRefreshRequest(PasswordGrantConfig|DirectTok
     ClientConfiguration clientConfig;
 
     if (config is PasswordGrantConfig) {
-        RefreshConfig? refreshConfig = config?.refreshConfig;
-        if (refreshConfig is RefreshConfig) {
+        var refreshConfig = config?.refreshConfig;
+        if (refreshConfig is record {}) {
             string? clientId = config?.clientId;
             string? clientSecret = config?.clientSecret;
             if (clientId is string && clientSecret is string) {

--- a/oauth2-ballerina/client_oauth2_provider.bal
+++ b/oauth2-ballerina/client_oauth2_provider.bal
@@ -327,7 +327,9 @@ isolated function getAccessTokenFromRefreshRequest(PasswordGrantConfig|RefreshTo
 
     if (config is PasswordGrantConfig) {
         var refreshConfig = config?.refreshConfig;
-        if (refreshConfig is record {}) {
+        if (refreshConfig is ()) {
+            return prepareError("Failed to refresh access-token since refresh configurations are not provided.");
+        } else {
             string? clientId = config?.clientId;
             string? clientSecret = config?.clientSecret;
             if (clientId is string && clientSecret is string) {
@@ -347,8 +349,6 @@ isolated function getAccessTokenFromRefreshRequest(PasswordGrantConfig|RefreshTo
             } else {
                 return prepareError("Client-id or client-secret cannot be empty.");
             }
-        } else {
-            return prepareError("Failed to refresh access-token since refresh configurations are not provided.");
         }
         defaultTokenExpTime = config.defaultTokenExpTime;
         clockSkew = config.clockSkew;

--- a/oauth2-ballerina/client_oauth2_provider.bal
+++ b/oauth2-ballerina/client_oauth2_provider.bal
@@ -74,7 +74,7 @@ public type PasswordGrantConfig record {|
     ClientConfiguration clientConfig = {};
 |};
 
-# The data structure, which can be used to pass the configurations for refreshing the access token directly.
+# The data structure, which can be used to configure OAuth2 refresh token grant type.
 #
 # + refreshUrl - Refresh token URL for the refresh token server
 # + refreshToken - Refresh token for the refresh token server
@@ -86,7 +86,7 @@ public type PasswordGrantConfig record {|
 # + optionalParams - Map of optional parameters use for the authorization endpoint
 # + credentialBearer - Bearer of the authentication credentials, which is sent to the authorization endpoint
 # + clientConfig - HTTP client configurations, which are used to call the authorization endpoint
-public type DirectTokenConfig record {|
+public type RefreshTokenGrantConfig record {|
     string refreshUrl;
     string refreshToken;
     string clientId;
@@ -119,10 +119,10 @@ type RequestConfig record {|
 |};
 
 # Represents the grant type configurations supported for OAuth2.
-public type GrantConfig ClientCredentialsGrantConfig|PasswordGrantConfig|DirectTokenConfig;
+public type GrantConfig ClientCredentialsGrantConfig|PasswordGrantConfig|RefreshTokenGrantConfig;
 
 # Represents the client OAuth2 provider, which generates OAuth2 tokens. This supports the client credentials grant type,
-# password grant type, and the direct token type, which sends the access token directly.
+# password grant type, and the refresh token grant type.
 #
 # 1. Client Credentials Grant Type
 # ```ballerina
@@ -146,7 +146,7 @@ public type GrantConfig ClientCredentialsGrantConfig|PasswordGrantConfig|DirectT
 # });
 # ```
 #
-# 3. Direct Token Type
+# 3. Refresh Token Grant Type
 # ```ballerina
 # oauth2:ClientOAuth2Provider provider = new({
 #     refreshUrl: "https://localhost:9196/oauth2/token/refresh",
@@ -196,7 +196,7 @@ isolated function generateOAuth2Token(GrantConfig grantConfig, TokenCache tokenC
     } else if (grantConfig is ClientCredentialsGrantConfig) {
         return getOAuth2TokenForClientCredentialsGrant(grantConfig, tokenCache);
     } else {
-        return getOAuth2TokenForDirectTokenType(grantConfig, tokenCache);
+        return getOAuth2TokenForRefreshTokenGrantType(grantConfig, tokenCache);
     }
 }
 
@@ -240,8 +240,8 @@ isolated function getOAuth2TokenForClientCredentialsGrant(ClientCredentialsGrant
     }
 }
 
-// Processes the OAuth2 token for the direct token type.
-isolated function getOAuth2TokenForDirectTokenType(DirectTokenConfig grantConfig,
+// Processes the OAuth2 token for the refresh token grant type.
+isolated function getOAuth2TokenForRefreshTokenGrantType(RefreshTokenGrantConfig grantConfig,
                                                    TokenCache tokenCache) returns string|Error {
     string cachedAccessToken = tokenCache.accessToken;
     if (cachedAccessToken == "") {
@@ -317,7 +317,7 @@ isolated function getAccessTokenFromAuthorizationRequest(ClientCredentialsGrantC
 }
 
 // Requests an access-token from the authorization endpoint using the provided refresh configurations.
-isolated function getAccessTokenFromRefreshRequest(PasswordGrantConfig|DirectTokenConfig config,
+isolated function getAccessTokenFromRefreshRequest(PasswordGrantConfig|RefreshTokenGrantConfig config,
                                                    TokenCache tokenCache) returns string|Error {
     RequestConfig requestConfig;
     decimal defaultTokenExpTime;

--- a/oauth2-ballerina/oauth2_commons.bal
+++ b/oauth2-ballerina/oauth2_commons.bal
@@ -33,7 +33,7 @@ public type ClientConfiguration record {|
 |};
 
 # Defines the authentication configuration types for the HTTP client used for token introspection.
-public type ClientAuth ClientCredentialsGrantConfig|PasswordGrantConfig|DirectTokenConfig;
+public type ClientAuth ClientCredentialsGrantConfig|PasswordGrantConfig|RefreshTokenGrantConfig;
 
 # Represents HTTP versions.
 public enum HttpVersion {

--- a/oauth2-ballerina/tests/client_oauth2_provider_test.bal
+++ b/oauth2-ballerina/tests/client_oauth2_provider_test.bal
@@ -273,9 +273,9 @@ isolated function testPasswordGrantType3() {
 @test:Config {
     groups: ["provider"]
 }
-isolated function testDirectToken1() {
-    // Test the direct token mode with an invalid access token and a valid refresh config
-    DirectTokenConfig config = {
+isolated function testRefreshTokenGrantType1() {
+    // Test the refresh token grant type with an invalid access token and a valid refresh config
+    RefreshTokenGrantConfig config = {
         refreshUrl: "https://localhost:9443/oauth2/token",
         refreshToken: "invalid_refresh_token",
         clientId: "FlfJYKBD2c925h4lkycqNZlC2l4a",


### PR DESCRIPTION
## Purpose
This PR rename the `oauth2:DirectTokenConfig` into `oauth2:RefreshTokenGrantConfig`.

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/584