### PR TITLE
Add JWT bearer grant support for OAuth2

### DIFF
--- a/ballerina/client_oauth2_provider.bal
+++ b/ballerina/client_oauth2_provider.bal
@@ -100,6 +100,31 @@ public type RefreshTokenGrantConfig record {|
     ClientConfiguration clientConfig = {};
 |};
 
+# Represents the data structure, which is used to configure the OAuth2 JWT bearer grant type.
+#
+# + tokenUrl - Token URL of the token endpoint
+# + assertion - A single JWT for the JWT bearer grant type
+# + clientId - Client ID for the client authentication
+# + clientSecret - Client secret for the client authentication
+# + scopes - Scope(s) of the access request
+# + defaultTokenExpTime - Expiration time (in seconds) of the tokens if the token endpoint response does not contain an `expires_in` field
+# + clockSkew - Clock skew (in seconds) that can be used to avoid token validation failures due to clock synchronization problems
+# + optionalParams - Map of optional parameters use for the token endpoint
+# + credentialBearer - Bearer of the authentication credentials, which is sent to the token endpoint
+# + clientConfig - HTTP client configurations, which are used to call the token endpoint
+public type JwtBearerGrantConfig record {|
+    string tokenUrl;
+    string assertion;
+    string clientId?;
+    string clientSecret?;
+    string[] scopes?;
+    decimal defaultTokenExpTime = 3600;
+    decimal clockSkew = 0;
+    map<string> optionalParams?;
+    CredentialBearer credentialBearer = AUTH_HEADER_BEARER;
+    ClientConfiguration clientConfig = {};
+|};
+
 // The data structure, which stores the values needed to prepare the HTTP request, which are to be sent to the
 // token endpoint.
 type RequestConfig record {|
@@ -112,11 +137,11 @@ type RequestConfig record {|
 |};
 
 # Represents the grant type configurations supported for OAuth2.
-public type GrantConfig ClientCredentialsGrantConfig|PasswordGrantConfig|RefreshTokenGrantConfig;
+public type GrantConfig ClientCredentialsGrantConfig|PasswordGrantConfig|RefreshTokenGrantConfig|JwtBearerGrantConfig;
 
 # Represents the client OAuth2 provider, which is used to generate OAuth2 access tokens using the configured OAuth2
-# token endpoint configurations. This supports the client credentials grant type, password grant type, and the
-# refresh token grant type.
+# token endpoint configurations. This supports the client credentials grant type, password grant type,
+# refresh token grant type, and the JWT bearer grant type.
 #
 # 1. Client Credentials Grant Type
 # ```ballerina
@@ -190,8 +215,10 @@ isolated function generateOAuth2Token(GrantConfig grantConfig, TokenCache tokenC
         return getOAuth2TokenForClientCredentialsGrant(grantConfig, tokenCache);
     } else if (grantConfig is PasswordGrantConfig) {
         return getOAuth2TokenForPasswordGrant(grantConfig, tokenCache);
-    } else {
+    } else if (grantConfig is RefreshTokenGrantConfig) {
         return getOAuth2TokenForRefreshTokenGrantType(grantConfig, tokenCache);
+    } else {
+        return getOAuth2TokenForJwtBearerGrantType(grantConfig, tokenCache);
     }
 }
 
@@ -250,6 +277,26 @@ isolated function getOAuth2TokenForRefreshTokenGrantType(RefreshTokenGrantConfig
                     return tokenCache.getAccessToken();
                 }
                 return getAccessTokenFromRefreshRequestForRefreshTokenGrant(grantConfig, tokenCache);
+            }
+        }
+    }
+}
+
+// Processes the OAuth2 access token for the JWT BEARER GRANT type.
+isolated function getOAuth2TokenForJwtBearerGrantType(JwtBearerGrantConfig grantConfig,
+                                                      TokenCache tokenCache) returns string|Error {
+    string cachedAccessToken = tokenCache.getAccessToken();
+    if (cachedAccessToken == "") {
+        return getAccessTokenFromTokenRequestForJwtBearerGrant(grantConfig, tokenCache);
+    } else {
+        if (!tokenCache.isAccessTokenExpired()) {
+            return cachedAccessToken;
+        } else {
+            lock {
+                if (!tokenCache.isAccessTokenExpired()) {
+                    return tokenCache.getAccessToken();
+                }
+                return getAccessTokenFromTokenRequestForJwtBearerGrant(grantConfig, tokenCache);
             }
         }
     }
@@ -319,6 +366,45 @@ isolated function getAccessTokenFromTokenRequestForPasswordGrant(PasswordGrantCo
     string? refreshToken = extractRefreshToken(response);
     int? expiresIn = extractExpiresIn(response);
     tokenCache.update(accessToken, refreshToken, expiresIn, defaultTokenExpTime, clockSkew);
+    return accessToken;
+}
+
+// Requests an access token from the token endpoint using the provided JWT BEARER GRANT configurations.
+// Refer: https://tools.ietf.org/html/rfc7523#section-2.1
+isolated function getAccessTokenFromTokenRequestForJwtBearerGrant(JwtBearerGrantConfig config,
+                                                                  TokenCache tokenCache) returns string|Error {
+    string tokenUrl = config.tokenUrl;
+    string? clientId = config?.clientId;
+    string? clientSecret = config?.clientSecret;
+    RequestConfig requestConfig;
+    if (clientId is string && clientSecret is string) {
+        if (clientId == "" || clientSecret == "") {
+            return prepareError("Client-id or client-secret cannot be empty.");
+        }
+        requestConfig = {
+            payload: "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" + config.assertion,
+            clientId: clientId,
+            clientSecret: clientSecret,
+            scopes: config?.scopes,
+            optionalParams: config?.optionalParams,
+            credentialBearer: config.credentialBearer
+        };
+    } else {
+        requestConfig = {
+            payload: "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" + config.assertion,
+            scopes: config?.scopes,
+            optionalParams: config?.optionalParams,
+            credentialBearer: config.credentialBearer
+        };
+    }
+    decimal defaultTokenExpTime = config.defaultTokenExpTime;
+    decimal clockSkew = config.clockSkew;
+    ClientConfiguration clientConfig = config.clientConfig;
+
+    json response = check sendRequest(requestConfig, tokenUrl, clientConfig);
+    string accessToken = check extractAccessToken(response);
+    int? expiresIn = extractExpiresIn(response);
+    tokenCache.update(accessToken, (), expiresIn, defaultTokenExpTime, clockSkew);
     return accessToken;
 }
 

--- a/ballerina/tests/client_oauth2_provider_test.bal
+++ b/ballerina/tests/client_oauth2_provider_test.bal
@@ -796,3 +796,58 @@ isolated function testJwtBearerGrantType5() {
         test:assertFail(msg = "Test Failed! ");
     }
 }
+
+// Test the JWT bearer grant type with an valid JWT
+@test:Config {}
+isolated function testJwtBearerGrantType6() {
+    string jwt = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTXpZeE1tRmtPR1l3TVdJMFpXTm1ORGN4TkdZd1ltTTRaVEEzTV" +
+                 "dJMk5EQXpaR1F6TkdNMFpHIn0.eyJpc3MiOiJodHRwczovL2xvY2FsaG9zdDo5NDQzL29hdXRoMi90b2tlbiIsICJzdWIiOiJh" +
+                 "ZG1pbiIsICJhdWQiOiJodHRwczovL2xvY2FsaG9zdDo5NDQzL29hdXRoMi90b2tlbiIsICJleHAiOjE5NDQ0NzI2MjksICJuYm" +
+                 "YiOjE2MjkxMTI2MjksICJpYXQiOjE2MjkxMTI2Mjl9.Qbi5kElPZlyViUUuYW9Ik4nXSeTIroacEDs4BoI0rAGAOBXfyWLW4Yx" +
+                 "m6hAlb4GXtkPZ4YMO8c0mUgdXgvPVFqFYJuINNPu6Y_nExahAVD0VxCYRE59lEjRv7t_gqn5OxSu_jTGcgcHH8_j-tvL_-AHaq" +
+                 "gflr5UljbTPtnQyXtLaPNeu3r7FoWs-LrewMPIm1aw5qc2gI2iYwI1jfIdpNlEjU6r_Mg6ou2D2AGqJa0QYN1FMqi4YJt2jHr6" +
+                 "0tQMQIWJ7zhKU4ShZESxYOVKK_cBOeL6K-A07pNEZYaSxtCU3609MIZ8EOUJuQUJb7zHHxG4QziHM8eBwFo26yovBFw";
+    JwtBearerGrantConfig config = {
+        tokenUrl: "https://localhost:9443/oauth2/token",
+        assertion: jwt,
+        clientId: "uDMwA4hKR9H3deeXxvNf4sSU0i4a",
+        clientSecret: "8FOUOKUQfOp47pUfJCsPA5X4clga",
+        scopes: ["view-order"],
+        optionalParams: {
+            "client": "ballerina"
+        },
+        clientConfig: {
+            secureSocket: {
+               cert: WSO2_PUBLIC_CERT_PATH
+            }
+        }
+    };
+    ClientOAuth2Provider provider = new(config);
+    string|Error response = provider.generateToken();
+    if (response is string) {
+        assertToken(response);
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+
+    // Send the credentials in request body
+    config.credentialBearer = POST_BODY_BEARER;
+    provider = new(config);
+    response = provider.generateToken();
+    if (response is string) {
+        assertToken(response);
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+
+    // The access token is valid only for 2 seconds. Wait 5 seconds and try again so that the access token will be
+    // reissued by the provided configurations.
+    runtime:sleep(5.0);
+
+    response = provider.generateToken();
+    if (response is string) {
+        assertToken(response);
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+}

--- a/ballerina/tests/client_oauth2_provider_test.bal
+++ b/ballerina/tests/client_oauth2_provider_test.bal
@@ -623,3 +623,176 @@ isolated function testRefreshTokenGrantType3() {
         test:assertFail(msg = "Test Failed! ");
     }
 }
+
+// ---------------- JWT BEARER GRANT TYPE ----------------
+
+// Test the JWT bearer grant type with an valid JWT
+@test:Config {}
+isolated function testJwtBearerGrantType1() {
+    string jwt = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTXpZeE1tRmtPR1l3TVdJMFpXTm1ORGN4TkdZd1ltTTRaVEEzTV" +
+                 "dJMk5EQXpaR1F6TkdNMFpHIn0.eyJpc3MiOiJodHRwczovL2xvY2FsaG9zdDo5NDQzL29hdXRoMi90b2tlbiIsICJzdWIiOiJh" +
+                 "ZG1pbiIsICJhdWQiOiJodHRwczovL2xvY2FsaG9zdDo5NDQzL29hdXRoMi90b2tlbiIsICJleHAiOjE5NDQ0NzI2MjksICJuYm" +
+                 "YiOjE2MjkxMTI2MjksICJpYXQiOjE2MjkxMTI2Mjl9.Qbi5kElPZlyViUUuYW9Ik4nXSeTIroacEDs4BoI0rAGAOBXfyWLW4Yx" +
+                 "m6hAlb4GXtkPZ4YMO8c0mUgdXgvPVFqFYJuINNPu6Y_nExahAVD0VxCYRE59lEjRv7t_gqn5OxSu_jTGcgcHH8_j-tvL_-AHaq" +
+                 "gflr5UljbTPtnQyXtLaPNeu3r7FoWs-LrewMPIm1aw5qc2gI2iYwI1jfIdpNlEjU6r_Mg6ou2D2AGqJa0QYN1FMqi4YJt2jHr6" +
+                 "0tQMQIWJ7zhKU4ShZESxYOVKK_cBOeL6K-A07pNEZYaSxtCU3609MIZ8EOUJuQUJb7zHHxG4QziHM8eBwFo26yovBFw";
+    JwtBearerGrantConfig config = {
+        tokenUrl: "https://localhost:9443/oauth2/token",
+        assertion: jwt,
+        clientId: "uDMwA4hKR9H3deeXxvNf4sSU0i4a",
+        clientSecret: "8FOUOKUQfOp47pUfJCsPA5X4clga",
+        scopes: ["view-order"],
+        optionalParams: {
+            "client": "ballerina"
+        },
+        clientConfig: {
+            secureSocket: {
+               cert: WSO2_PUBLIC_CERT_PATH
+            }
+        }
+    };
+    ClientOAuth2Provider provider = new(config);
+    string|Error response = provider.generateToken();
+    if (response is string) {
+        assertToken(response);
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+
+    // Send the credentials in request body
+    config.credentialBearer = POST_BODY_BEARER;
+    provider = new(config);
+    response = provider.generateToken();
+    if (response is string) {
+        assertToken(response);
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+}
+
+// Test the JWT bearer grant type with an valid JWT (different issuer)
+@test:Config {}
+isolated function testJwtBearerGrantType2() {
+    string jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxN" +
+                 "TE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    JwtBearerGrantConfig config = {
+        tokenUrl: "https://localhost:9443/oauth2/token",
+        assertion: jwt,
+        clientId: "uDMwA4hKR9H3deeXxvNf4sSU0i4a",
+        clientSecret: "8FOUOKUQfOp47pUfJCsPA5X4clga",
+        scopes: ["view-order"],
+        optionalParams: {
+            "client": "ballerina"
+        },
+        clientConfig: {
+            secureSocket: {
+               cert: WSO2_PUBLIC_CERT_PATH
+            }
+        }
+    };
+    ClientOAuth2Provider|error provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "{\"error_description\":\"Internal Server Error.\",\"error\":\"server_error\"}");
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+}
+
+// Test the JWT bearer grant type with an invalid assertion
+@test:Config {}
+isolated function testJwtBearerGrantType3() {
+    JwtBearerGrantConfig config = {
+        tokenUrl: "https://localhost:9443/oauth2/token",
+        assertion: "invalid-assertion",
+        clientId: "uDMwA4hKR9H3deeXxvNf4sSU0i4a",
+        clientSecret: "8FOUOKUQfOp47pUfJCsPA5X4clga",
+        scopes: ["view-order"],
+        optionalParams: {
+            "client": "ballerina"
+        },
+        clientConfig: {
+            secureSocket: {
+               cert: WSO2_PUBLIC_CERT_PATH
+            }
+        }
+    };
+    ClientOAuth2Provider|error provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "{\"error_description\":\"Error while parsing the JWT.\",\"error\":\"invalid_grant\"}");
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+}
+
+// Test the JWT bearer grant type with empty client-id and client-secret
+@test:Config {}
+isolated function testJwtBearerGrantType4() {
+    string jwt = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTXpZeE1tRmtPR1l3TVdJMFpXTm1ORGN4TkdZd1ltTTRaVEEzTV" +
+                 "dJMk5EQXpaR1F6TkdNMFpHIn0.eyJpc3MiOiJodHRwczovL2xvY2FsaG9zdDo5NDQzL29hdXRoMi90b2tlbiIsICJzdWIiOiJh" +
+                 "ZG1pbiIsICJhdWQiOiJodHRwczovL2xvY2FsaG9zdDo5NDQzL29hdXRoMi90b2tlbiIsICJleHAiOjE5NDQ0NzI2MjksICJuYm" +
+                 "YiOjE2MjkxMTI2MjksICJpYXQiOjE2MjkxMTI2Mjl9.Qbi5kElPZlyViUUuYW9Ik4nXSeTIroacEDs4BoI0rAGAOBXfyWLW4Yx" +
+                 "m6hAlb4GXtkPZ4YMO8c0mUgdXgvPVFqFYJuINNPu6Y_nExahAVD0VxCYRE59lEjRv7t_gqn5OxSu_jTGcgcHH8_j-tvL_-AHaq" +
+                 "gflr5UljbTPtnQyXtLaPNeu3r7FoWs-LrewMPIm1aw5qc2gI2iYwI1jfIdpNlEjU6r_Mg6ou2D2AGqJa0QYN1FMqi4YJt2jHr6" +
+                 "0tQMQIWJ7zhKU4ShZESxYOVKK_cBOeL6K-A07pNEZYaSxtCU3609MIZ8EOUJuQUJb7zHHxG4QziHM8eBwFo26yovBFw";
+    JwtBearerGrantConfig config = {
+        tokenUrl: "https://localhost:9443/oauth2/token",
+        assertion: jwt,
+        clientId: "",
+        clientSecret: "",
+        scopes: ["view-order"],
+        optionalParams: {
+            "client": "ballerina"
+        },
+        clientConfig: {
+            secureSocket: {
+               cert: WSO2_PUBLIC_CERT_PATH
+            }
+        }
+    };
+    ClientOAuth2Provider|error provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "Client-id or client-secret cannot be empty.");
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+
+    // Send the credentials in request body
+    config.credentialBearer = POST_BODY_BEARER;
+    provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "Client-id or client-secret cannot be empty.");
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+}
+
+// Test the JWT bearer grant type with an valid JWT, and without client-id and client-secret
+@test:Config {}
+isolated function testJwtBearerGrantType5() {
+    string jwt = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTXpZeE1tRmtPR1l3TVdJMFpXTm1ORGN4TkdZd1ltTTRaVEEzTV" +
+                 "dJMk5EQXpaR1F6TkdNMFpHIn0.eyJpc3MiOiJodHRwczovL2xvY2FsaG9zdDo5NDQzL29hdXRoMi90b2tlbiIsICJzdWIiOiJh" +
+                 "ZG1pbiIsICJhdWQiOiJodHRwczovL2xvY2FsaG9zdDo5NDQzL29hdXRoMi90b2tlbiIsICJleHAiOjE5NDQ0NzI2MjksICJuYm" +
+                 "YiOjE2MjkxMTI2MjksICJpYXQiOjE2MjkxMTI2Mjl9.Qbi5kElPZlyViUUuYW9Ik4nXSeTIroacEDs4BoI0rAGAOBXfyWLW4Yx" +
+                 "m6hAlb4GXtkPZ4YMO8c0mUgdXgvPVFqFYJuINNPu6Y_nExahAVD0VxCYRE59lEjRv7t_gqn5OxSu_jTGcgcHH8_j-tvL_-AHaq" +
+                 "gflr5UljbTPtnQyXtLaPNeu3r7FoWs-LrewMPIm1aw5qc2gI2iYwI1jfIdpNlEjU6r_Mg6ou2D2AGqJa0QYN1FMqi4YJt2jHr6" +
+                 "0tQMQIWJ7zhKU4ShZESxYOVKK_cBOeL6K-A07pNEZYaSxtCU3609MIZ8EOUJuQUJb7zHHxG4QziHM8eBwFo26yovBFw";
+    JwtBearerGrantConfig config = {
+        tokenUrl: "https://localhost:9443/oauth2/token",
+        assertion: jwt,
+        scopes: ["view-order"],
+        optionalParams: {
+            "client": "ballerina"
+        },
+        clientConfig: {
+            secureSocket: {
+               cert: WSO2_PUBLIC_CERT_PATH
+            }
+        }
+    };
+    ClientOAuth2Provider|error provider = trap new(config);
+    if (provider is error) {
+        assertContains(provider, "{\"error_description\":\"Unsupported Client Authentication Method!\",\"error\":\"invalid_client\"}");
+    } else {
+        test:assertFail(msg = "Test Failed! ");
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,11 @@ This file contains all the notable changes done to the Ballerina OAuth2 package 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- [Add JWT bearer grant support for OAuth2](https://github.com/ballerina-platform/ballerina-standard-library/issues/1716)
+
 ## [1.1.0-beta.1] - 2021-05-06
 
 ### Changed


### PR DESCRIPTION
## Purpose
This PR adds the JWT bearer grant support for OAuth2 according to the Section-2.1 of RFC 7523 [1].

```
   The following example demonstrates an access token request with a JWT
   as an authorization grant (with extra line breaks for display
   purposes only):

     POST /token.oauth2 HTTP/1.1
     Host: as.example.com
     Content-Type: application/x-www-form-urlencoded

     grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer
     &assertion=eyJhbGciOiJFUzI1NiIsImtpZCI6IjE2In0.
     eyJpc3Mi[...omitted for brevity...].
     J9l-ZhwP[...omitted for brevity...]
```

[1] https://datatracker.ietf.org/doc/html/rfc7523#section-2.1

Fixes https://github.com/ballerina-platform/ballerina-standard-library/issues/1716

## Examples

```ballerina
import ballerina/oauth2;

public function main() {
    string jwt = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTXpZeE1tRmtPR1l3TVdJMFpXTm1ORGN4TkdZd1ltTTRaVEEzTV" +
                 "dJMk5EQXpaR1F6TkdNMFpHIn0.eyJpc3MiOiJodHRwczovL2xvY2FsaG9zdDo5NDQzL29hdXRoMi90b2tlbiIsICJzdWIiOiJh" +
                 "ZG1pbiIsICJhdWQiOiJodHRwczovL2xvY2FsaG9zdDo5NDQzL29hdXRoMi90b2tlbiIsICJleHAiOjE5NDQ0NzI2MjksICJuYm" +
                 "YiOjE2MjkxMTI2MjksICJpYXQiOjE2MjkxMTI2Mjl9.Qbi5kElPZlyViUUuYW9Ik4nXSeTIroacEDs4BoI0rAGAOBXfyWLW4Yx" +
                 "m6hAlb4GXtkPZ4YMO8c0mUgdXgvPVFqFYJuINNPu6Y_nExahAVD0VxCYRE59lEjRv7t_gqn5OxSu_jTGcgcHH8_j-tvL_-AHaq" +
                 "gflr5UljbTPtnQyXtLaPNeu3r7FoWs-LrewMPIm1aw5qc2gI2iYwI1jfIdpNlEjU6r_Mg6ou2D2AGqJa0QYN1FMqi4YJt2jHr6" +
                 "0tQMQIWJ7zhKU4ShZESxYOVKK_cBOeL6K-A07pNEZYaSxtCU3609MIZ8EOUJuQUJb7zHHxG4QziHM8eBwFo26yovBFw";
    oauth2:JwtBearerGrantConfig config = {
        tokenUrl: "https://localhost:9443/oauth2/token",
        assertion: jwt,
        clientId: "uDMwA4hKR9H3deeXxvNf4sSU0i4a",
        clientSecret: "8FOUOKUQfOp47pUfJCsPA5X4clga",
        scopes: ["view-order"],
        optionalParams: {
            "client": "ballerina"
        },
        clientConfig: {
            secureSocket: {
               cert: WSO2_PUBLIC_CERT_PATH
            }
        }
    };

    oauth2:ClientOAuth2Provider provider = new(config);
    string|oauth2:Error response = provider.generateToken();
}
```

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
