### PR TITLE
Return nil explicitly from functions

### DIFF
--- a/ballerina/client_oauth2_provider.bal
+++ b/ballerina/client_oauth2_provider.bal
@@ -606,6 +606,7 @@ isolated function extractRefreshToken(json response) returns string? {
         return refreshToken;
     } else {
         log:printDebug("Failed to access 'refresh_token' property from the JSON.");
+        return;
     }
 }
 
@@ -615,6 +616,7 @@ isolated function extractExpiresIn(json response) returns int? {
         return expiresIn;
     } else {
         log:printDebug("Failed to access 'expires_in' property from the JSON as an int.");
+        return;
     }
 }
 

--- a/ballerina/listener_oauth2_provider.bal
+++ b/ballerina/listener_oauth2_provider.bal
@@ -274,6 +274,7 @@ isolated function validateFromCache(cache:Cache oauth2Cache, string token) retur
             if (result is cache:Error) {
                 log:printError("Failed to invalidate OAuth2 access token from the cache.", 'error = result);
             }
+            return;
         }
     } else {
         log:printError("Failed to validate the token from the cache.", 'error = cachedEntry);


### PR DESCRIPTION
## Purpose
$subject to remove the warning `this function should explicitly return a value`.

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
