### PR TITLE
Increase load test time for 1-hour

### DIFF
--- a/load-tests/order_management_service/scripts/run.sh
+++ b/load-tests/order_management_service/scripts/run.sh
@@ -19,4 +19,4 @@
 set -e
 source base-scenario.sh
 
-jmeter -n -t "$scriptsDir/"http-post-request.jmx -l "$resultsDir/"original.jtl -Jusers=10 -Jduration=1200 -Jhost=bal.perf.test -Jport=443 -Jprotocol=https -Jpath=order $payload_flags
+jmeter -n -t "$scriptsDir/"http-post-request.jmx -l "$resultsDir/"original.jtl -Jusers=10 -Jduration=3600 -Jhost=bal.perf.test -Jport=443 -Jprotocol=https -Jpath=order $payload_flags


### PR DESCRIPTION
## Purpose
This is related to https://github.com/ballerina-platform/module-ballerina-oauth2/pull/375

## Checklist
- [ ] ~Linked to an issue~
- [ ] ~Updated the changelog~
- [ ] ~Added tests~
