### PR TITLE
Allow all 2xx status codes as successful response of token endpoint

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- [Oauth2 client treats 201-Created response as a failure](https://github.com/ballerina-platform/ballerina-standard-library/issues/3334)
+
 ### Changed
 - [Append the scheme of the HTTP client URL (token/introspection) based on the client configurations](https://github.com/ballerina-platform/ballerina-standard-library/issues/2816)
 

--- a/native/src/main/java/io/ballerina/stdlib/oauth2/OAuth2Client.java
+++ b/native/src/main/java/io/ballerina/stdlib/oauth2/OAuth2Client.java
@@ -297,7 +297,7 @@ public class OAuth2Client {
     private static Object callEndpoint(HttpClient client, HttpRequest request) {
         try {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() == 200) {
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
                 return StringUtils.fromString(response.body());
             }
             return createError("Failed to get a success response from the endpoint. Response code: '" +


### PR DESCRIPTION
## Purpose
Fixes: [#3334](https://github.com/ballerina-platform/ballerina-standard-library/issues/3334)

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
