### PR TITLE
Fix Java exception when tokenUrl set to empty string and Client Treats 201 Response as a Failure 

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -80,7 +80,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.4.0"
+version = "2.4.1"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/ballerina/tests/client_oauth2_provider_test.bal
+++ b/ballerina/tests/client_oauth2_provider_test.bal
@@ -875,3 +875,57 @@ isolated function testAccessTokenRequestWithSecureSocketAndWithHttpUrlScheme() r
     string response = check provider.generateToken();
     assertToken(response);
 }
+
+@test:Config {}
+isolated function testInvalidTokenUrl() returns Error? {
+    ClientCredentialsGrantConfig config = {
+        tokenUrl: "",
+        clientId: "FlfJYKBD2c925h4lkycqNZlC2l4a",
+        clientSecret: "PJz0UhTJMrHOo68QQNpvnqAY_3Aa",
+        scopes: ["view-order"],
+        clientConfig: {
+            secureSocket: {
+                cert: {
+                    path: TRUSTSTORE_PATH,
+                    password: "ballerina"
+                }
+            }
+        }
+    };
+    ClientOAuth2Provider|error provider = trap new (config);
+    if provider is Error {
+        test:assertEquals(provider.message(), "Failed to call the token endpoint ''.");
+        test:assertTrue(provider.cause() is Error);
+        Error cause = <Error>provider.cause();
+        test:assertEquals(cause.message(), "Failed to create URI for the provided value \"\".");
+    } else {
+        test:assertFail("The provider should be an oauth2:Error");
+    }
+}
+
+@test:Config {}
+isolated function testInvalidTokenUrl2() returns Error? {
+    ClientCredentialsGrantConfig config = {
+        tokenUrl: "https://abc d.com",
+        clientId: "FlfJYKBD2c925h4lkycqNZlC2l4a",
+        clientSecret: "PJz0UhTJMrHOo68QQNpvnqAY_3Aa",
+        scopes: ["view-order"],
+        clientConfig: {
+            secureSocket: {
+                cert: {
+                    path: TRUSTSTORE_PATH,
+                    password: "ballerina"
+                }
+            }
+        }
+    };
+    ClientOAuth2Provider|error provider = trap new (config);
+    if provider is Error {
+        test:assertEquals(provider.message(), "Failed to call the token endpoint 'https://abc d.com'.");
+        test:assertTrue(provider.cause() is Error);
+        Error cause = <Error>provider.cause();
+        test:assertEquals(cause.message(), "Failed to create URI for the provided value \"https://abc d.com\".");
+    } else {
+        test:assertFail("The provider should be an oauth2:Error");
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Changed
+- [API docs updated](https://github.com/ballerina-platform/ballerina-standard-library/issues/3463)
+
+### Fixed
+- [Java exception when tokenUrl set to empty string in OAuth2GrantConfig](https://github.com/ballerina-platform/ballerina-standard-library/issues/3402)
+
+## [2.3.0] - 2022-04-30
+
+### Changed
 - [Append the scheme of the HTTP client URL (token/introspection) based on the client configurations](https://github.com/ballerina-platform/ballerina-standard-library/issues/2816)
 
 ## [2.0.0] - 2021-10-10

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - [Java exception when tokenUrl set to empty string in OAuth2GrantConfig](https://github.com/ballerina-platform/ballerina-standard-library/issues/3402)
+- [Fix Oauth2 Client Treats 201-Created Response as a Failure](https://github.com/ballerina-platform/ballerina-standard-library/issues/3334)
 
 ## [2.3.0] - 2022-04-30
 

--- a/native/src/main/java/io/ballerina/stdlib/oauth2/OAuth2Client.java
+++ b/native/src/main/java/io/ballerina/stdlib/oauth2/OAuth2Client.java
@@ -303,7 +303,7 @@ public class OAuth2Client {
     private static Object callEndpoint(HttpClient client, HttpRequest request) {
         try {
             HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-            if (response.statusCode() == 200) {
+            if (response.statusCode() >= 200 && response.statusCode() < 300) {
                 return StringUtils.fromString(response.body());
             }
             return createError("Failed to get a success response from the endpoint. Response code: '" +

--- a/native/src/main/java/io/ballerina/stdlib/oauth2/OAuth2Client.java
+++ b/native/src/main/java/io/ballerina/stdlib/oauth2/OAuth2Client.java
@@ -82,7 +82,13 @@ public class OAuth2Client {
         BMap<BString, ?> secureSocket = getBMapValueIfPresent(clientConfig, OAuth2Constants.SECURE_SOCKET);
 
         HttpRequest request;
-        URI uri = buildUri(url.getValue(), secureSocket);
+        URI uri;
+        try {
+            uri = buildUri(url.getValue(), secureSocket);
+        } catch (IllegalArgumentException e) {
+            return createError("Failed to create URI for the provided value \"" + url + "\".");
+        }
+
         if (headersList.isEmpty()) {
             request = buildHttpRequest(uri, textPayload);
         } else {
@@ -103,7 +109,7 @@ public class OAuth2Client {
         return callEndpoint(client, request);
     }
 
-    private static URI buildUri(String url, BMap<BString, ?> secureSocket) {
+    private static URI buildUri(String url, BMap<BString, ?> secureSocket) throws IllegalArgumentException {
         String[] urlParts = url.split(OAuth2Constants.SCHEME_SEPARATOR, 2);
         if (urlParts.length == 1) {
             urlParts = secureSocket != null ? new String[]{OAuth2Constants.HTTPS_SCHEME, urlParts[0]} :
@@ -316,7 +322,7 @@ public class OAuth2Client {
     }
 
     private static BError createError(String errMsg) {
-        return ErrorCreator.createDistinctError(OAuth2Constants.OAUTH2_ERROR_TYPE, ModuleUtils.getModule(),
-                                                StringUtils.fromString(errMsg));
+        return ErrorCreator.createError(ModuleUtils.getModule(), OAuth2Constants.OAUTH2_ERROR_TYPE,
+                                        StringUtils.fromString(errMsg), null, null);
     }
 }


### PR DESCRIPTION
## Purpose

Fixes: [#3402](https://github.com/ballerina-platform/ballerina-standard-library/issues/3402), [#3334](https://github.com/ballerina-platform/ballerina-standard-library/issues/3334)

## Examples

## Checklist
- [x] Linked to an issue
- [x] Updated the changelog
- [x] Added tests
- [ ] ~~Updated the spec~~
- [ ] ~~Checked native-image compatibility~~
