### PR TITLE
Disable testJwtBearerGrantType1 test case

### DIFF
--- a/ballerina/tests/client_oauth2_provider_test.bal
+++ b/ballerina/tests/client_oauth2_provider_test.bal
@@ -680,7 +680,8 @@ isolated function testRefreshTokenGrantType4() {
 
 // Test the JWT bearer grant type with an valid JWT
 @test:Config {
-    groups: ["skipOnWindows"]
+    groups: ["skipOnWindows"],
+    enable: false
 }
 isolated function testJwtBearerGrantType1() returns Error? {
     string jwt = "eyJhbGciOiJSUzI1NiIsICJ0eXAiOiJKV1QiLCAia2lkIjoiTXpZeE1tRmtPR1l3TVdJMFpXTm1ORGN4TkdZd1ltTTRaVEEzTV" +


### PR DESCRIPTION
## Purpose
This test case is failing due to expired certificate found in wso2-is container. This PR temporarily disables the test case. Following issue is created to track this: https://github.com/ballerina-platform/ballerina-library/issues/6968 
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
