### PR TITLE
[2201.12.x] Expose connection and request timeout of the internal HTTP client as global configs

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.0"
+version = "2.14.1"
 authors = ["Ballerina"]
 keywords = ["security", "authorization", "introspection"]
 repository = "https://github.com/ballerina-platform/module-ballerina-oauth2"
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "oauth2-native"
-version = "2.14.0"
-path = "../native/build/libs/oauth2-native-2.14.0.jar"
+version = "2.14.1"
+path = "../native/build/libs/oauth2-native-2.14.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -130,7 +130,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},

--- a/ballerina/init.bal
+++ b/ballerina/init.bal
@@ -16,10 +16,34 @@
 
 import ballerina/jballerina.java;
 
-isolated function init() {
+# Represents the default connection timeout values for the oauth2 client.
+public const decimal DEFAULT_CONNECT_TIMEOUT = 15;
+
+# Represents the default request timeout value for the oauth2 client.
+public const decimal DEFAULT_REQ_TIMEOUT = 30;
+
+# Represents the maximum time(in seconds) to wait for a connection to be established with the oauth2 endpoint.
+# Defaults to 15 seconds. This is a global configuration which will be applied to all the internal oauth2 client calls.
+public configurable decimal globalConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
+
+# Represents the maximum time(in seconds) to wait for a response before the oauth2 endpoint request times out.
+# Defaults to 30 seconds. This is a global configuration which will be applied to all the internal oauth2 client calls.
+public configurable decimal globalReqTimeout = DEFAULT_REQ_TIMEOUT;
+
+isolated function init() returns error? {
     setModule();
+    check setOauth2ConnectionTimeout(globalConnectTimeout);
+    check setOauth2RequestTimeout(globalReqTimeout);
 }
 
 isolated function setModule() = @java:Method {
+    'class: "io.ballerina.stdlib.oauth2.ModuleUtils"
+} external;
+
+isolated function setOauth2ConnectionTimeout(decimal timeout) returns error? = @java:Method {
+    'class: "io.ballerina.stdlib.oauth2.ModuleUtils"
+} external;
+
+isolated function setOauth2RequestTimeout(decimal timeout) returns error? = @java:Method {
     'class: "io.ballerina.stdlib.oauth2.ModuleUtils"
 } external;

--- a/ballerina/tests/client_oauth2_provider_test.bal
+++ b/ballerina/tests/client_oauth2_provider_test.bal
@@ -919,6 +919,35 @@ isolated function testAccessTokenRequestWithoutUrlScheme() returns Error? {
 @test:Config {
     groups: ["skipOnWindows"]
 }
+isolated function testAccessTokenRequestWithDelay() returns Error? {
+    ClientCredentialsGrantConfig config = {
+        tokenUrl: "http://localhost:9444/oauth2/token",
+        clientId: "FlfJYKBD2c925h4lkycqNZlC2l4a",
+        clientSecret: "PJz0UhTJMrHOo68QQNpvnqAY_3Aa",
+        scopes: "view-order",
+        clientConfig: {
+            customHeaders: {
+                "X-Delay": "40"
+            }
+        }
+    };
+
+    ClientOAuth2Provider|error provider = trap new(config);
+    if provider is error {
+        assertContains(provider, "Failed to call the token endpoint 'http://localhost:9444/oauth2/token'. Failed to send the request to the endpoint. request timed out");
+    } else {
+        test:assertFail("Expected error not found.");
+    }
+
+    config.clientConfig.customHeaders["X-Delay"] = "10";
+    ClientOAuth2Provider provider1 = new(config);
+    string response = check provider1.generateToken();
+    assertToken(response);
+}
+
+@test:Config {
+    groups: ["skipOnWindows"]
+}
 isolated function testAccessTokenRequestWithHttpUrlScheme() returns Error? {
     ClientCredentialsGrantConfig config = {
         tokenUrl: "http://localhost:9444/oauth2/token",

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,12 @@ This file contains all the notable changes done to the Ballerina OAuth2 package 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- [Expose global connection timeout and request timeout for the internal HTTP client used to obtain token or introspect, with default values](https://github.com/ballerina-platform/ballerina-library/issues/8121)
+
 ## [2.13.0] - 2025-02-11
 
 - This version maintains the latest dependency versions. 

--- a/native/src/main/java/io/ballerina/stdlib/oauth2/ModuleUtils.java
+++ b/native/src/main/java/io/ballerina/stdlib/oauth2/ModuleUtils.java
@@ -20,6 +20,9 @@ package io.ballerina.stdlib.oauth2;
 
 import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.Module;
+import io.ballerina.runtime.api.creators.ErrorCreator;
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BDecimal;
 
 /**
  * Utility functions relevant to module operations.
@@ -29,6 +32,8 @@ import io.ballerina.runtime.api.Module;
 public class ModuleUtils {
 
     private static Module oauth2Module;
+    private static double oauth2ConnectionTimeout = 15.0;
+    private static double oauth2RequestTimeout = 30.0;
 
     private ModuleUtils() {}
 
@@ -38,5 +43,35 @@ public class ModuleUtils {
 
     public static Module getModule() {
         return oauth2Module;
+    }
+
+    public static Object setOauth2ConnectionTimeout(BDecimal timeout) {
+        double doubleValue = timeout.floatValue();
+        if (doubleValue <= 0) {
+            String errMsg = "OAuth2 connection timeout must be greater than zero";
+            return ErrorCreator.createError(ModuleUtils.getModule(), OAuth2Constants.OAUTH2_ERROR_TYPE,
+                    StringUtils.fromString(errMsg), null, null);
+        }
+        oauth2ConnectionTimeout = doubleValue;
+        return null;
+    }
+
+    public static double getOauth2ConnectionTimeout() {
+        return oauth2ConnectionTimeout;
+    }
+
+    public static Object setOauth2RequestTimeout(BDecimal timeout) {
+        double doubleValue = timeout.floatValue();
+        if (doubleValue <= 0) {
+            String errMsg = "OAuth2 request timeout must be greater than zero";
+            return ErrorCreator.createError(ModuleUtils.getModule(), OAuth2Constants.OAUTH2_ERROR_TYPE,
+                    StringUtils.fromString(errMsg), null, null);
+        }
+        oauth2RequestTimeout = doubleValue;
+        return null;
+    }
+
+    public static double getOauth2RequestTimeout() {
+        return oauth2RequestTimeout;
     }
 }

--- a/native/src/main/java/io/ballerina/stdlib/oauth2/OAuth2Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/oauth2/OAuth2Constants.java
@@ -48,6 +48,8 @@ public class OAuth2Constants {
     public static final BString PASSWORD = StringUtils.fromString("password");
     public static final BString CUSTOM_HEADERS = StringUtils.fromString("customHeaders");
     public static final BString CUSTOM_PAYLOAD = StringUtils.fromString("customPayload");
+    public static final BString CONNECTION_TIMEOUT = StringUtils.fromString("connectTimeout");
+    public static final BString REQUEST_TIMEOUT = StringUtils.fromString("reqTimeout");
 
     public static final String TLS = "TLS";
     public static final String PKCS12 = "PKCS12";


### PR DESCRIPTION
## Purpose

> $Subject

Part of: https://github.com/ballerina-platform/ballerina-library/issues/8121

## Examples

Sample configuration to overwrite the default timeouts:

```toml
[ballerina.oauth2]
globalConnectTimeout = 30.0
globalReqTimeout = 60.0
```

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
